### PR TITLE
Move classes to Reflekt module

### DIFF
--- a/lib/accessor.rb
+++ b/lib/accessor.rb
@@ -8,6 +8,7 @@
 #   - @@reflekt_skipped_methods on the instance's singleton class
 ################################################################################
 
+module Reflekt
 class Accessor
 
   attr_accessor :config
@@ -34,4 +35,5 @@ class Accessor
 
   end
 
+end
 end

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -7,6 +7,7 @@
 #   3. Meta
 ################################################################################
 
+module Reflekt
 class Action
 
   attr_accessor :unique_id
@@ -85,4 +86,5 @@ class Action
     return true
   end
 
+end
 end

--- a/lib/action_stack.rb
+++ b/lib/action_stack.rb
@@ -4,6 +4,7 @@
 # @pattern Stack
 ################################################################################
 
+module Reflekt
 class ActionStack
 
   def initialize()
@@ -41,4 +42,5 @@ class ActionStack
 
   end
 
+end
 end

--- a/lib/clone.rb
+++ b/lib/clone.rb
@@ -12,6 +12,7 @@
 #   3. Clone <- YOU ARE HERE
 ################################################################################
 
+module Reflekt
 class Clone
 
   def initialize(action)
@@ -28,4 +29,5 @@ class Clone
     @caller_object_clone.send(method, *new_args)
   end
 
+end
 end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,3 +1,4 @@
+module Reflekt
 class Config
 
   attr_accessor :enabled
@@ -39,4 +40,5 @@ class Config
 
   end
 
+end
 end

--- a/lib/control.rb
+++ b/lib/control.rb
@@ -21,6 +21,7 @@
 require_relative 'reflection'
 require_relative 'meta_builder'
 
+module Reflekt
 class Control < Reflection
 
   ##
@@ -80,4 +81,5 @@ class Control < Reflection
 
   end
 
+end
 end

--- a/lib/experiment.rb
+++ b/lib/experiment.rb
@@ -21,6 +21,7 @@
 require_relative 'reflection'
 require_relative 'meta_builder'
 
+module Reflekt
 class Experiment < Reflection
 
   ##
@@ -78,4 +79,5 @@ class Experiment < Reflection
 
   end
 
+end
 end

--- a/lib/meta.rb
+++ b/lib/meta.rb
@@ -10,6 +10,7 @@
 #   3. Meta <- YOU ARE HERE
 ################################################################################
 
+module Reflekt
 class Meta
 
   ##
@@ -68,4 +69,5 @@ class Meta
 
   end
 
+end
 end

--- a/lib/meta/array_meta.rb
+++ b/lib/meta/array_meta.rb
@@ -1,5 +1,6 @@
 require_relative '../meta'
 
+module Reflekt
 class ArrayMeta < Meta
 
   def initialize()
@@ -31,4 +32,5 @@ class ArrayMeta < Meta
     }
   end
 
+end
 end

--- a/lib/meta/boolean_meta.rb
+++ b/lib/meta/boolean_meta.rb
@@ -1,5 +1,6 @@
 require_relative '../meta'
 
+module Reflekt
 class BooleanMeta < Meta
 
   def initialize()
@@ -23,4 +24,5 @@ class BooleanMeta < Meta
     }
   end
 
+end
 end

--- a/lib/meta/float_meta.rb
+++ b/lib/meta/float_meta.rb
@@ -1,5 +1,6 @@
 require_relative '../meta'
 
+module Reflekt
 class FloatMeta < Meta
 
   def initialize()
@@ -23,4 +24,5 @@ class FloatMeta < Meta
     }
   end
 
+end
 end

--- a/lib/meta/integer_meta.rb
+++ b/lib/meta/integer_meta.rb
@@ -1,5 +1,6 @@
 require_relative '../meta'
 
+module Reflekt
 class IntegerMeta < Meta
 
   def initialize()
@@ -23,4 +24,5 @@ class IntegerMeta < Meta
     }
   end
 
+end
 end

--- a/lib/meta/null_meta.rb
+++ b/lib/meta/null_meta.rb
@@ -12,6 +12,7 @@
 
 require_relative '../meta'
 
+module Reflekt
 class NullMeta < Meta
 
   def initialize()
@@ -31,4 +32,5 @@ class NullMeta < Meta
     }
   end
 
+end
 end

--- a/lib/meta/string_meta.rb
+++ b/lib/meta/string_meta.rb
@@ -1,5 +1,6 @@
 require_relative '../meta'
 
+module Reflekt
 class StringMeta < Meta
 
   def initialize()
@@ -23,4 +24,5 @@ class StringMeta < Meta
     }
   end
 
+end
 end

--- a/lib/meta_builder.rb
+++ b/lib/meta_builder.rb
@@ -9,6 +9,7 @@ require_relative 'meta'
 # Require all meta.
 Dir[File.join(__dir__, 'meta', '*.rb')].each { |file| require_relative file }
 
+module Reflekt
 class MetaBuilder
 
   ##
@@ -81,4 +82,5 @@ class MetaBuilder
 
   end
 
+end
 end

--- a/lib/reflection.rb
+++ b/lib/reflection.rb
@@ -20,6 +20,7 @@
 require_relative 'clone'
 require_relative 'meta_builder'
 
+module Reflekt
 class Reflection
 
   attr_reader :status
@@ -145,4 +146,5 @@ class Reflection
 
   end
 
+end
 end

--- a/lib/renderer.rb
+++ b/lib/renderer.rb
@@ -1,3 +1,4 @@
+module Reflekt
 class Renderer
 
   def initialize(path, output_path)
@@ -36,4 +37,5 @@ class Renderer
   end
 
 
+end
 end

--- a/lib/rule.rb
+++ b/lib/rule.rb
@@ -11,6 +11,7 @@
 # @see lib/rules for rules.
 ################################################################################
 
+module Reflekt
 class Rule
 
   attr_reader :type
@@ -49,4 +50,5 @@ class Rule
   def random()
   end
 
+end
 end

--- a/lib/rule_set.rb
+++ b/lib/rule_set.rb
@@ -15,6 +15,7 @@ require 'set'
 require_relative 'meta_builder'
 require_relative 'meta/null_meta.rb'
 
+module Reflekt
 class RuleSet
 
   attr_accessor :rules
@@ -106,4 +107,5 @@ class RuleSet
   end
 
 
+end
 end

--- a/lib/rule_set_aggregator.rb
+++ b/lib/rule_set_aggregator.rb
@@ -12,6 +12,7 @@
 
 require_relative 'rule_set'
 
+module Reflekt
 class RuleSetAggregator
 
   ##
@@ -257,4 +258,5 @@ class RuleSetAggregator
 
   end
 
+end
 end

--- a/lib/rules/array_rule.rb
+++ b/lib/rules/array_rule.rb
@@ -1,5 +1,6 @@
 require_relative '../rule'
 
+module Reflekt
 class ArrayRule < Rule
 
   def initialize()
@@ -85,4 +86,5 @@ class ArrayRule < Rule
 
   end
 
+end
 end

--- a/lib/rules/boolean_rule.rb
+++ b/lib/rules/boolean_rule.rb
@@ -1,6 +1,7 @@
 require 'set'
 require_relative '../rule'
 
+module Reflekt
 class BooleanRule < Rule
 
   def initialize()
@@ -44,4 +45,5 @@ class BooleanRule < Rule
     @booleans.to_a.sample
   end
 
+end
 end

--- a/lib/rules/float_rule.rb
+++ b/lib/rules/float_rule.rb
@@ -1,5 +1,6 @@
 require_relative '../rule'
 
+module Reflekt
 class FloatRule < Rule
 
   def initialize()
@@ -54,4 +55,5 @@ class FloatRule < Rule
     rand(@min..@max)
   end
 
+end
 end

--- a/lib/rules/integer_rule.rb
+++ b/lib/rules/integer_rule.rb
@@ -1,5 +1,6 @@
 require_relative '../rule'
 
+module Reflekt
 class IntegerRule < Rule
 
   def initialize()
@@ -54,4 +55,5 @@ class IntegerRule < Rule
     rand(@min..@max)
   end
 
+end
 end

--- a/lib/rules/null_rule.rb
+++ b/lib/rules/null_rule.rb
@@ -1,5 +1,6 @@
 require_relative '../rule'
 
+module Reflekt
 class NullRule < Rule
 
   def initialize()
@@ -30,4 +31,5 @@ class NullRule < Rule
     nil
   end
 
+end
 end

--- a/lib/rules/string_rule.rb
+++ b/lib/rules/string_rule.rb
@@ -1,5 +1,6 @@
 require_relative '../rule'
 
+module Reflekt
 class StringRule < Rule
 
   attr_accessor :min_length
@@ -78,4 +79,5 @@ class StringRule < Rule
 
   end
 
+end
 end


### PR DESCRIPTION
Since classes are defined at the top level, they may unintentionally break classes defined elsewhere.
Therefore, this moves them to Reflekt module.